### PR TITLE
Some ideas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 *.key
 credentials.*
+
+# Node schluessel credentials keys
+credentials.*.key

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "schluessel",
       "version": "1.0.3",
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/src/cred.js
+++ b/src/cred.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const crypto = require('crypto');
 const files = require('./files.js');
 const errors = require('./error.js');
+const editFile = require('./edit-file');
 
 const ivLen = 12;
 const tagLen = 16;

--- a/src/edit-file.js
+++ b/src/edit-file.js
@@ -46,18 +46,31 @@ const defaultEditor = () => {
   return unixEditor();
 };
 
-module.exports = (file) => {
-  const ret = cp.spawnSync(
-    defaultEditor(),
-    [file],
-    {
-      stdio: ['inherit', 'inherit', 'inherit'],
-      windowsHide: true,
-      shell: true,
-    },
-  );
+module.exports = 
+  (file, editor_override) => {
+    var theEditor;
+    if(editor_override.length < 1) {
+      theEditor = defaultEditor();
+    } else {
+      if (editor_override=='code') {
+        editor_override = 'code --wait'; //need it to wait for file to close
+      }
+      theEditor = editor_override;
+    }
+    console.log(`edit-file.js>editor set to: ${theEditor}`);
+    const ret = cp.spawnSync(
+      theEditor,
+      [file],
+      {
+        stdio: ['inherit', 'inherit', 'inherit'],
+        windowsHide: true,
+        shell: true,
+      },
+    );
 
-  if ('error' in ret) {
-    throw ret.error;
+    if ('error' in ret) {
+      throw ret.error;
+    }
   }
-};
+
+

--- a/src/files.js
+++ b/src/files.js
@@ -16,7 +16,11 @@ const key = `credentials.${env.toLowerCase()}.key`;
  */
 const mpath = (global.isCli ? process.cwd() : appRoot.path);
 const vaultFile = `${mpath}/${vault}`;
-const keyFile = `${mpath}/${key}`;
+var keyFile = `${mpath}/${key}`;
+
+function setKeyPath(path){
+  this.keyFile = `${path}/${key}`;
+}
 
 module.exports = {
   environment: env,
@@ -25,4 +29,5 @@ module.exports = {
   key,
   vaultFile,
   keyFile,
+  setKeyPath
 };


### PR DESCRIPTION
Hello,
Not sure this fits your product vision (which is quite elegant), but I wanted the option to:
1) Store key files outside the main project path:  I added a -k or --key-path arg that takes a path
2) Use a non-default text editor (although the code that detects the default editor is impressive): I added a -e or --editor arg that overrides the default editor, and if it is "code", I make sure to run "code --wait"  so that the UI doesn't return to the spawning window until after the file is closed.

Windows 10:
Tested new & edit with no arguments, tested edit with -k, tested edit with -e, tested edit with -k and -e - I think it works.
I don't have a linux distro handy. Yes, I know that is sad.

All the best either way and thanks for this package :-)